### PR TITLE
Hotfix/ModuleNotFoundError

### DIFF
--- a/text_classification/text_datasets.py
+++ b/text_classification/text_datasets.py
@@ -10,10 +10,10 @@ import numpy
 
 import chainer
 
-from nlp_utils import make_vocab
-from nlp_utils import normalize_text
-from nlp_utils import split_text
-from nlp_utils import transform_to_array
+from .nlp_utils import make_vocab
+from .nlp_utils import normalize_text
+from .nlp_utils import split_text
+from .nlp_utils import transform_to_array
 
 URL_DBPEDIA = 'https://github.com/le-scientifique/torchDatasets/raw/master/dbpedia_csv.tar.gz'  # NOQA
 URL_IMDB = 'http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz'


### PR DESCRIPTION
**Error**

```
(dev3) ┌─────── suhubdyd@eos15 [~/research/fall2018/contextual_augmentation] (master)
└─ λ python -u train.py -g 0 --train datasets/wikitext-103-raw/spacy_wikitext-103-raw.train --valid datasets/wikitext-103-raw/spacy_wikitext-103-raw.valid --vocab datasets/wikitext-103-raw/spacy_wikitext-103-raw.train.vocab.t50 -u 1024 --layer 2 --dropout 0.1 --batchsize 64 --out trained_bilm
Traceback (most recent call last):
  File "train.py", line 13, in <module>
    from text_classification import text_datasets
  File "/u/suhubdyd/research/fall2018/contextual_augmentation/text_classification/text_datasets.py", line 13, in <module>
    from nlp_utils import make_vocab
ModuleNotFoundError: No module named 'nlp_utils'
```

**Changes**

- adding . to indicate module in text_c;assification/text_datasets.py